### PR TITLE
Restore calculation annotations and type usages

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -170,7 +170,9 @@ Amount* and *Floating Amount* , the ISDA 2006 definitions of Day Count
 Fraction rules, and performance calculations for Equity Swaps. The CDM
 also specifies related utility functions.
 
-These calculation processes are specified as functions in the Rune DSL.
+These calculation processes leverage the *calculation function*
+component of the Rune DSL which is associated to a `[calculation]`
+annotation.
 
 Explanations of these processes are provided in the following sections.
 
@@ -451,6 +453,7 @@ structure: a calculation formula that reflects the terms of the ISDA
 
 ``` Haskell
 func FloatingAmount:
+  [calculation]
   inputs:
       interestRatePayout InterestRatePayout (1..1)
       rate number (0..1)
@@ -493,6 +496,7 @@ example below:
 
 ``` Haskell
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30E_360):
+   [calculation]
 
    alias startYear: startDate -> year
    alias endYear: endDate -> year

--- a/docs/product-model.md
+++ b/docs/product-model.md
@@ -449,8 +449,8 @@ type InterestRatePayout extends PayoutBase:
    cashflowRepresentation CashflowRepresentation (0..1)
    stubPeriod StubPeriod (0..1)
    bondReference BondReference (0..1)
-   fixedAmount string (0..1)
-   floatingAmount string (0..1)
+   fixedAmount calculation (0..1)
+   floatingAmount calculation (0..1)
 ```
 
 ---

--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <rune-fpml.version>3.2.0</rune-fpml.version>
-        <rosetta.dsl.version>10.0.0-dev.15</rosetta.dsl.version>
-        <rosetta.bundle.version>12.0.0-dev.22</rosetta.bundle.version>
+        <rosetta.dsl.version>10.0.0-dev.16</rosetta.dsl.version>
+        <rosetta.bundle.version>12.0.0-dev.23</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/rosetta-source/src/main/rosetta/base-datetime-daycount-func.rosetta
+++ b/rosetta-source/src/main/rosetta/base-datetime-daycount-func.rosetta
@@ -6,6 +6,7 @@ import cdm.base.datetime.*
 // ** following is the new year fraction calculation logic, which is independent of the calculation period generation logic
 func YearFraction: <"The fraction of a year represented by a date range">
     [codeImplementation]
+    [calculation]
     inputs:
         dayCountFractionEnum DayCountFractionEnum (1..1) <"The day count fraction to use">
         startDate date (1..1) <"The start date of the range for which the year fraction is required">
@@ -16,9 +17,11 @@ func YearFraction: <"The fraction of a year represented by a date range">
         result number (1..1) <"The fraction of a year represented by period from the startDate to the endDate">
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _1_1): <"2006 ISDA Definition Article 4 section 4.16(a):	if '1/1' is specified, 1;.">
+    [calculation]
     set result: 1.0
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_ACT_ISDA): <"'2021 ISDA Definitions Section 4.6.1(ii): if 'Actual/Actual', 'Actual/Actual(ISDA)', 'Act/Act' or 'Act/Act(ISDA)' is specified, the actual number of days in the Calculation Period or Compounding Period in respect of which the calculation is being made divided by 365 (or, if any portion of that Calculation Period or Compounding Period falls in a leap year, the sum of (1) the actual number of days in that portion of the Calculation Period or Compounding Period falling in a leap year divided by 366 and (2) the actual number of days in that portion of the Calculation Period or Compounding Period falling a non-leap year divided by 365), calculated as follows: (daysInNonLeapPeriod/365)+(daysInLeapYearPeriod/366)' '2006 ISDA Definition Article 4 section 4.16(b): if 'Actual/Actual', 'Actual/Actual(ISDA)', 'Act/Act' or 'Act/Act(ISDA)' is specified, the actual number of days in the Calculation Period or Compounding Period in respect of which the calculation is being made divided by 365 (or, if any portion of that Calculation Period or Compounding Period falls in a leap year, the sum of (1) the actual number of days in that portion of the Calculation Period or Compounding Period falling in a leap year divided by 366 and (2) the actual number of days in that portion of the Calculation Period or Compounding Period falling a non-leap year divided by 365).'">
+    [calculation]
     alias daysInPeriod: DateDifference(startDate, endDate)
     alias daysInLeapYearPeriod: <"the actual number of days in that portion of the Calculation Period or Compounding Period falling in a leap year.">
         LeapYearDateDifference(startDate, endDate)
@@ -27,18 +30,22 @@ func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_ACT_ISDA): <
     set result: (daysInNonLeapPeriod / 365) + (daysInLeapYearPeriod / 366)
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_ACT_ICMA): <"'2021 ISDA Definitions Section 4.6.1(iii): if 'Actual/Actual(ICMA)' or 'Act/Act(ICMA)'' is specified, a fraction calculated in accordance with Rule 251 of the statutes, by-laws, rules and recommendations of the International Capital Market Association (or any successor thereto), as applied to non-U.S. Dollar denominated straight and convertible bonds issued after December 31, 1998, as though the interest coupon on a bond were being calculated for a coupon period corresponding to the relevant Calculation Period or Compounding Period.' '2006 ISDA Definition Article 4 section 4.16(c):	(c)	if 'Actual/Actual (ICMA)' or 'Act/Act (ICMA)' is specified, a fraction equal to 'number of days accrued/number of days in year', as such terms are used in Rule 251 of the statutes, by-laws, rules and recommendations of the International Capital Market Association (the 'ICMA Rule Book'), calculated in accordance with Rule 251 of the ICMA Rule Book as applied to non US dollar denominated straight and convertible bonds issued after December 31, 1998, as though the interest coupon on a bond were being calculated for a coupon period corresponding to the Calculation Period or Compounding Period in respect of which payment is being made;.">
+    [calculation]
     alias daysInPeriod: DateDifference(startDate, endDate)
     set result: daysInPeriod / (daysInPeriod * periodsInYear)
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_365_FIXED): <"'2021 ISDA Definitions Section 4.6.1(iv): if 'Actual/365(Fixed)', 'Act/365(Fixed)', 'A/365(Fixed)'or 'A/365F' is specified, the actual number of days in the relevant Calculation Period or Compounding Period divided by 365, calculated as follows: (daysInPeriod/365)' '2006 ISDA Definition Article 4 section 4.16(d): If 'Actual/365 (Fixed)', 'Act/365 (Fixed)', 'A/365 (Fixed)' or 'A/365F' is specified, the actual number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 365.">
+    [calculation]
     alias daysInPeriod: DateDifference(startDate, endDate)
     set result: daysInPeriod / 365
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_360): <"'2021 ISDA Definitions Section 4.6.1(v): if 'Actual/360', 'Act/360' or 'A/360' is specified, the actual number of days in the relevant Calculation Period or Compounding Period divided by 360, calculated as follows: (daysInPeriod/360)' '2006 ISDA Definition Article 4 section 4.16(e): if 'Actual/360', 'Act/360' or 'A/360' is specified, the actual number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 360.'">
+    [calculation]
     alias daysInPeriod: DateDifference(startDate, endDate)
     set result: daysInPeriod / 360
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30_360): <"'2021 ISDA Definitions Section 4.6.1(vi): if '30/360', '360/360' or 'Bond Basis' is specified, the number of days in the relevant Calculation Period or Compounding Period divided by 360, calculated as follows: [360 x (Y2 - Y1)] + [30 x (M2 - M1)] + (D2 - D1)]/360' '2006 ISDA Definition Article 4 section 4.16(f): if '30/360', '360/360' or 'Bond Basis' is specified, the number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 360, calculated on a formula basis as follows:[[360 x (Y2 - Y1)] + [30 x (M2 - M1)] + (D2 - D1)]/360.''">
+    [calculation]
 
     alias startYear: <"The year, expressed as a number, in which the first day of the Calculation Period or Compounding Period falls.">
         startDate -> year
@@ -63,6 +70,7 @@ func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30_360): <"'202
         (360 * (endYear - startYear) + 30 * (endMonth - startMonth) + (endDay - startDay)) / 360
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30E_360): <"'2021 ISDA Definitions Section 4.6.1(vii): if '30E/360' or 'Eurobond Basis' is specified, the number of days in the relevant Calculation Period or Compounding Period divided by 360, calculated as follows: [[360 x (Y2 - Y1)] + [30 x (M2 - M1)] + (D2 - D1)]/360' '2006 ISDA Definition Article 4 section 4.16(e): if 'Actual/360', 'Act/360' or 'A/360' is specified, the actual number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 360 calculated on a formula basis as follows:[[360 x (Y2 - Y1)] + [30 x (M2 - M1)] + (D2 - D1)]/360.'">
+    [calculation]
 
     alias startYear: <"The year, expressed as a number, in which the first day of the Calculation Period or Compounding Period falls.">
         startDate -> year
@@ -85,6 +93,7 @@ func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30E_360): <"'20
         (360 * (endYear - startYear) + 30 * (endMonth - startMonth) + (endDay - startDay)) / 360
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30E_360_ISDA): <"2006 ISDA Definition Article 4 section 4.16(h): if '30E/360 (ISDA)' is specified, the number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 360, calculated on a formula basis as follows: [[360 × (Y2 - Y1)]+[30 × (M2 - M1)] +(D2 - D1)]/360 .">
+    [calculation]
 
     alias startDateIsInLeapYear: IsLeapYear(startDate -> year)
 
@@ -126,10 +135,12 @@ func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> _30E_360_ISDA): 
         (360 * (endYear - startYear) + 30 * (endMonth - startMonth) + (endDay - startDay)) / 360
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_364): <"the actual number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 364.">
+    [calculation]
     alias daysInPeriod: DateDifference(startDate, endDate)
     set result: daysInPeriod / 364
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_365L): <"'2021 ISDA Definitions Section 4.6.1(ix): if 'Act/365L' is specified, the actual number of days in the relevant Calculation Period or Compounding Period divided by 365 (or, if the later Period End Date of the Calculation Period or Compounding Date of the Compounding Period falls in a leap year, divided by 366)' 'The actual number of days in the Calculation Period or Compounding Period in respect of which payment is being made divided by 365 (or, if the later Period End Date of the Calculation Period or Compounding Period falls in a leap year, divided by 366).'">
+    [calculation]
 
     alias endDateIsInLeapYear: IsLeapYear(endDate -> year)
 
@@ -141,10 +152,12 @@ func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> ACT_365L): <"'20
     set result: daysInPeriod / daysInYear
 
 func YearFraction(dayCountFractionEnum: DayCountFractionEnum -> CAL_252): <"'2021 ISDA Definitions Section 4.6.1(x): if 'Calculation/252' is specified, the actual number of Calculation Days in the relevant Calculation Period or Compounding Period divided by 252, calculated as follows: [daysInPeriod/252], where 'daysInPeriod' is, unless otherwise specified in the Confirmation, in respect of the relevant Floating Amount or Fixed Amount to which this Day Count Fraction applies, the Business Days in the relevant Calculation Period or Compounding Period determined by reference to the Business Day and Business Day Convention applicable to the determination of such Floating Amount or Fixed Amount, as applicable.">
+    [calculation]
     alias daysInPeriod: DateDifference(startDate, endDate)
     set result: daysInPeriod / 252
 
 func YearFractionForOneDay: <"Return the year fraction represented by a single day, i.e 1 / dayCountBasis, where daycountBasis represents the denominator of the day count fraction. This perhaps should take into account leap years, though the ISDA compounding formulas do not cover ACT basis at the moment.">
+    [calculation]
     inputs:
         dcf DayCountFractionEnum (1..1) <"Supplied Day count fraction.">
     output:
@@ -154,6 +167,7 @@ func YearFractionForOneDay: <"Return the year fraction represented by a single d
 
 func DayCountBasis: <"Return the day count basis (the denominator of the day count fraction) for the day count fraction.">
     [codeImplementation]
+    [calculation]
     inputs:
         dcf DayCountFractionEnum (1..1) <"Day count fraction.">
     output:

--- a/rosetta-source/src/main/rosetta/legaldocumentation-csa-func.rosetta
+++ b/rosetta-source/src/main/rosetta/legaldocumentation-csa-func.rosetta
@@ -7,6 +7,7 @@ import cdm.observable.asset.*
 
 func PostedCreditSupportItemAmount: <"Calculates the Value for the given Posted Credit Support item.">
     [docReference ISDA CSA_IM_NewYork_2018 paragraph "13"]
+    [calculation]
     inputs:
         postedItem PostedCreditSupportItem (1..1) <"Posted Credit Support Item.">
         baseCurrency string (1..1) <"Base Currency means the currency specified as such in Paragraph 13.">
@@ -35,6 +36,7 @@ func PostedCreditSupportItemAmount: <"Calculates the Value for the given Posted 
     set result -> unit -> currency: baseCurrency
 
 func UndisputedAdjustedPostedCreditSupportAmount: <"Calculates the value for Undisputed Adjusted Posted Credit Support Item.">
+    [calculation]
     inputs:
         postedCreditSupportItems PostedCreditSupportItem (0..*) <"Posted Credit Support Items.">
         priorDeliveryAmountAdjustment Money (1..1) <"The adjustment value to include any prior Delivery Amount (IM).">
@@ -67,6 +69,7 @@ func UndisputedAdjustedPostedCreditSupportAmount: <"Calculates the value for Und
     set result -> unit -> currency: baseCurrency
 
 func CreditSupportAmount: <"Calculates the Credit Support Amount.">
+    [calculation]
     inputs:
         marginAmount Money (1..1) <"The Base Currency Equivalent of an amount equal to the sum of the initial margin amounts.">
             [docReference ISDA CSA_IM_2018 paragraph "3" clause "(c)(i)"]
@@ -108,6 +111,7 @@ func CreditSupportAmount: <"Calculates the Credit Support Amount.">
 
 func ReturnAmount:
     [docReference ISDA CSA_IM_2018 paragraph "3" clause "(b)"]
+    [calculation]
     inputs:
         postedCreditSupportItems PostedCreditSupportItem (0..*)
         priorDeliveryAmountAdjustment Money (1..1) <"The adjustment value to include any prior Delivery Amount (IM).">
@@ -180,6 +184,7 @@ func ReturnAmount:
 
 func DeliveryAmount:
     [docReference ISDA CSA_IM_2018 paragraph "3" clause "a" name "Delivery Amount"]
+    [calculation]
     inputs:
         postedCreditSupportItems PostedCreditSupportItem (0..*)
         priorDeliveryAmountAdjustment Money (1..1) <"The adjustment value to include any prior Delivery Amount (IM).">

--- a/rosetta-source/src/main/rosetta/product-asset-calculation-func.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-calculation-func.rosetta
@@ -43,6 +43,7 @@ func FixedAmountCalculation: <"Calculates the fixed amount for a calculation per
         calcAmt * fixedAmountDetails -> fixedRate * fixedAmountDetails -> yearFraction
 
 func GetFixedRate: <"Look up the fixed rate for a calculation period.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"An interest rate stream.">
         calculationPeriod CalculationPeriodBase (1..1) <"The calculation period for which you want the spread.">

--- a/rosetta-source/src/main/rosetta/product-asset-floatingrate-func.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-floatingrate-func.rosetta
@@ -79,12 +79,14 @@ func ProcessFloatingRateReset: <"Entry point for the function that performs the 
         floatingRate FloatingRateSettingDetails (1..1) <"Details of the rate observation/calculation.">
 
 func ProcessFloatingRateReset(processingType: FloatingRateIndexProcessingTypeEnum -> Screen): <"Evaluate the rate for a screen rate - call logic to determine how to observe the screen rate.">
+    [calculation]
     // set up convenience aliases
     alias resetDates: interestRatePayout -> resetDates
     alias rateDef: interestRatePayout -> rateSpecification -> FloatingRateSpecification
     set floatingRate: EvaluateScreenRate(rateDef, resetDates, calcPeriod) // Call the screen rate evaluation logic
 
 func ProcessFloatingRateReset(processingType: FloatingRateIndexProcessingTypeEnum -> Modular): <"Evaluate the rate for a modular calculated rate.  Call the calculated rate calculation logic to determine the value of the reset.">
+    [calculation]
     // set up convenience aliases
     alias rateDef: interestRatePayout -> rateSpecification -> FloatingRateSpecification
     alias resetDates: interestRatePayout -> resetDates
@@ -113,6 +115,7 @@ func ProcessFloatingRateReset(processingType: FloatingRateIndexProcessingTypeEnu
             )
 
 func ProcessFloatingRateReset(processingType: FloatingRateIndexProcessingTypeEnum -> OIS): <"Evaluate the rate for an OIS calculated rate. Call the calculated rate calculation logic to determine the value of the reset.  See the 2021 ISDA Definitions Section 6.6.3.">
+    [calculation]
     // set up convenience aliases
     alias rateDef: interestRatePayout -> rateSpecification -> FloatingRateSpecification
     alias resetDates: interestRatePayout -> resetDates
@@ -137,6 +140,7 @@ func ProcessFloatingRateReset(processingType: FloatingRateIndexProcessingTypeEnu
             )
 
 func ProcessFloatingRateReset(processingType: FloatingRateIndexProcessingTypeEnum -> OvernightAvg): <"Evaluate the rate for a daily average calculated FRO. Call the calculated rate calculation logic to determine the value of the reset. See the 2021 ISDA Definitions Section 6.6.3.">
+    [calculation]
     // set up convenience aliases
     alias rateDef: interestRatePayout -> rateSpecification -> FloatingRateSpecification
     alias resetDates: interestRatePayout -> resetDates
@@ -269,6 +273,7 @@ func GetFloatingRateProcessingParameters: <"Determine the processing parameters 
     set processingParameters -> negativeTreatment: negativeTreatment
 
 func SpreadAmount: <"Look up the spread amount for a calculation period.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"An interest rate stream.">
         calculationPeriod CalculationPeriodBase (1..1) <"The calculation period for which you want the spread.">
@@ -282,6 +287,7 @@ func SpreadAmount: <"Look up the spread amount for a calculation period.">
             )
 
 func MultiplierAmount: <"Look up the multiplier amount for a calculation period.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"An interest rate stream.">
         calculationPeriod CalculationPeriodBase (1..1) <"The calculation period for which you want the multiplier.">
@@ -295,6 +301,7 @@ func MultiplierAmount: <"Look up the multiplier amount for a calculation period.
             )
 
 func CapRateAmount: <"Look up the cap rate amount for a calculation period.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"An interest rate stream.">
         calculationPeriod CalculationPeriodBase (1..1) <"The calculation period for which you want the cap rate.">
@@ -308,6 +315,7 @@ func CapRateAmount: <"Look up the cap rate amount for a calculation period.">
             )
 
 func FloorRateAmount: <"Look up the floor rate amount for a calculation period.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"An interest rate stream.">
         calculationPeriod CalculationPeriodBase (1..1) <"The calculation period for which you want the floor rate.">
@@ -422,6 +430,7 @@ func ApplyFloatingRatePostSpreadProcessing: <"Perform post-spread rate treatment
     set processedRate: ApplyFinalRateRounding(cappedAndFlooredRate, processing -> rounding)
 
 func ApplyCapsAndFloors: <"Apply any cap or floor rate as a constraint on a regular swap rate, as discussed in the 2021 ISDA Definitions, section 6.5.8 and 6.5.9.">
+    [calculation]
     inputs:
         processing FloatingRateProcessingParameters (1..1)
         inputRate number (1..1) <"The floating rate prior to treatment, either a single term rate, or a calculated rate such as an OIS or lookback compounded rate.">
@@ -449,6 +458,7 @@ func ApplyUSRateTreatment: <"Apply the US rate treatment logic where applicable 
     set treatedRate: baseRate // temporary, stub definition until support is added
 
 func ApplyFinalRateRounding: <"Apply the final rate rounding treatment logic as described in the 2021 ISDA Definitions, section 4.8.1.">
+    [calculation]
     inputs:
         baseRate number (1..1) <"Rate before rounding.">
         finalRateRounding Rounding (0..1) <"type of rounding (precision and direction).">

--- a/rosetta-source/src/main/rosetta/product-asset-func.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-func.rosetta
@@ -10,6 +10,7 @@ import cdm.product.common.schedule.*
 import cdm.product.template.*
 
 func FixedAmount: <"2006 ISDA Definition Article 5 Section 5.1. Calculation of a Fixed Amount: The Fixed Amount payable by a party on a Payment Date will be: (a) if an amount is specified for the Swap Transaction as the Fixed Amount payable by that party for that Payment Date or for the related Calculation Period, that amount; or (b) if an amount is not specified for the Swap Transaction as the Fixed Amount payable by that party for that Payment Date or for the related Calculation Period, an amount calculated on a formula basis for that Payment Date or for the related Calculation Period as follows: Fixed Amount = Calculation Amount × Fixed Rate × Day Count Fraction.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"description of the interest rate payout">
         notional number (0..1) <"The notional quantity to use">
@@ -31,6 +32,7 @@ func FixedAmount: <"2006 ISDA Definition Article 5 Section 5.1. Calculation of a
     set fixedAmount: fixedAmountCalc -> calculatedAmount
 
 func FloatingAmount: <"2006 ISDA Definition Article 6 Section 6.1. Calculation of a Floating Amount: Subject to the provisions of Section 6.4 (Negative Interest Rates), the Floating Amount payable by a party on a Payment Date will be: (a) if Compounding is not specified for the Swap Transaction or that party, an amount calculated on a formula basis for that Payment Date or for the related Calculation Period as follows: Floating Amount = Calculation Amount × Floating Rate + Spread × Floating Rate Day Count Fraction (b) if 'Compounding' is specified to be applicable to the Swap Transaction or that party and 'Flat Compounding' is not specified, an amount equal to the sum of the Compounding Period Amounts for each of the Compounding Periods in the related Calculation Period; or (c) if 'Flat Compounding' is specified to be applicable to the Swap Transaction or that party, an amount equal to the sum of the Basic Compounding Period Amounts for each of the Compounding Periods in the related Calculation Period plus the sum of the Additional Compounding Period Amounts for each such Compounding Period.">
+    [calculation]
     inputs:
         interestRatePayout InterestRatePayout (1..1) <"full description of the interest rate payout">
         rate number (0..1) <"the floating rate to use; if omitted it is retrieved/calculated based on the interest rate payout and floating index ">

--- a/rosetta-source/src/main/rosetta/product-asset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-type.rosetta
@@ -156,8 +156,8 @@ type InterestRatePayout extends PayoutBase: <" A class to specify all of the ter
     cashflowRepresentation CashflowRepresentation (0..1) <"The cashflow representation of the swap stream.">
     stubPeriod StubPeriod (0..1) <"The stub calculation period amount parameters. This element must only be included if there is an initial or final stub calculation period. Even then, it must only be included if either the stub references a different floating rate tenor to the regular calculation periods, or if the stub is calculated as a linear interpolation of two different floating rate tenors, or if a specific stub rate or stub amount has been negotiated.">
     bondReference BondReference (0..1) <"Reference to a bond underlier to represent an asset swap or Condition Precedent Bond.">
-    fixedAmount string (0..1) <"Fixed Amount Calculation">
-    floatingAmount string (0..1) <"Floating Amount Calculation">
+    fixedAmount calculation (0..1) <"Fixed Amount Calculation">
+    floatingAmount calculation (0..1) <"Floating Amount Calculation">
     spreadCalculationMethod SpreadCalculationMethodEnum (0..1) <"Method by which spread is calculated. For example on an asset swap: 'ParPar' or 'Proceeds' may be the method indicated.">
 
     condition Quantity: <"When there is an OptionPayout the quantity can be expressed as part of the payoutQuantity, or as part of the underlier in the case of a Swaption.  For all other payouts that extend PayoutBase the payoutQuantity is a mandatory attribute.">
@@ -433,7 +433,7 @@ type DividendReturnTerms: <"A class describing the conditions governing the paym
     dividendReinvestment boolean (0..1) <"Boolean element that defines whether the dividend will be reinvested or not.">
     dividendEntitlement DividendEntitlementEnum (0..1) <"Defines the date on which the receiver of the equity return is entitled to the dividend.">
     dividendAmountType DividendAmountTypeEnum (0..1) <"Specifies whether the dividend is paid with respect to the Dividend Period.">
-    performance string (0..1) <"Performance calculation, in accordance with Part 1 Section 12 of the 2018 ISDA CDM Equity Confirmation for Security Equity Swap, Para 75. 'Equity Performance'. Cumulative performance is used as a notional multiplier factor on both legs of an Equity Swap.">
+    performance calculation (0..1) <"Performance calculation, in accordance with Part 1 Section 12 of the 2018 ISDA CDM Equity Confirmation for Security Equity Swap, Para 75. 'Equity Performance'. Cumulative performance is used as a notional multiplier factor on both legs of an Equity Swap.">
     firstOrSecondPeriod DividendPeriodEnum (0..1) <"2002 ISDA Equity Derivatives Definitions: Dividend Period as either the First Period or the Second Period. | ">
     extraordinaryDividendsParty AncillaryRoleEnum (0..1) <"Specifies the party which determines if dividends are extraordinary in relation to normal levels.">
     excessDividendAmount DividendAmountTypeEnum (0..1) <"Determination of Gross Cash Dividend per Share.">
@@ -466,7 +466,7 @@ type PriceReturnTerms:
 
     returnType ReturnTypeEnum (1..1) <"The type of return associated with the equity swap.">
     conversionFactor number (0..1) <"Defines the conversion applied if the quantity unit on contract is different from unit on referenced underlier.">
-    performance string (0..1) <"Performance calculation, in accordance with Part 1 Section 12 of the 2018 ISDA CDM Equity Confirmation for Security Equity Swap, Para 75. 'Equity Performance'. Cumulative performance is used as a notional multiplier factor on both legs of an Equity Swap.">
+    performance calculation (0..1) <"Performance calculation, in accordance with Part 1 Section 12 of the 2018 ISDA CDM Equity Confirmation for Security Equity Swap, Para 75. 'Equity Performance'. Cumulative performance is used as a notional multiplier factor on both legs of an Equity Swap.">
 
 type ReturnTermsBase: <"Contains all common elements in variance, volatility and correlation return Terms.">
 
@@ -479,7 +479,7 @@ type ReturnTermsBase: <"Contains all common elements in variance, volatility and
     initialLevel number (0..1) <"Contract will strike off this initial level. Providing just the initialLevel without initialLevelSource, infers that this is AgreedInitialPrice - a specified Initial Index Level.">
     initialLevelSource DeterminationMethodEnum (0..1) <"In this context, this is AgreedInitialPrice - a specified Initial Index Level.">
     meanAdjustment boolean (0..1) <"Specifies whether Mean Adjustment is applicable or not in the calculation of the Realized Volatility, Variance or Correlation">
-    performance string (0..1) <"Performance calculation, in accordance with Part 1 Section 12 of the 2018 ISDA CDM Equity Confirmation for Security Equity Swap, Para 75. 'Equity Performance'. Cumulative performance is used as a notional multiplier factor on both legs of an Equity Swap.">
+    performance calculation (0..1) <"Performance calculation, in accordance with Part 1 Section 12 of the 2018 ISDA CDM Equity Confirmation for Security Equity Swap, Para 75. 'Equity Performance'. Cumulative performance is used as a notional multiplier factor on both legs of an Equity Swap.">
 
     condition InitialLevelOrInitialLevelSource: <"At least one of initialLevel and initialLevelSource must be present, or both">
         if initialLevel is absent

--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -13,7 +13,7 @@ import cdm.product.common.schedule.*
 
 type ComputedAmount: <"A class to specify the outcome of a computed amount, for testing purposes.">
 
-    callFunction string (1..1)
+    callFunction calculation (1..1)
     amount number (1..1)
     currency string (0..1) <"The currency in which the computed amount is denominated. The list of valid currencies is not presently positioned as an enumeration as part of the CDM because that scope is limited to the values specified by ISDA and FpML. As a result, implementers have to make reference to the relevant standard, such as the ISO 4217 standard for currency codes.">
         [metadata scheme]

--- a/tests/src/test/resources/rosetta/test-func.rosetta
+++ b/tests/src/test/resources/rosetta/test-func.rosetta
@@ -13,6 +13,7 @@ func TestFunc2:
 	    result Test2
 
 func TestFunc2(directionEnum: DirectionEnum -> North):
+	[calculation]
 	alias daysInPeriod: TestFunc2(directionEnum)
 	alias daysInLeapYearPeriod:
 		TestFunc1(startDate, endDate)


### PR DESCRIPTION
# _Infrastructure - Dependency Update_

Version updates include:
  * `DSL` `10.0.0-dev.16` - Restores the `calculation` annotation and the `calculation` type alias, which are still used in production models as a placeholder for potential future usage. See DSL release notes: [10.0.0-dev.16](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.16)
  * `Bundle` `12.0.0-dev.23` - Restores the `calculation` type handling in the code generators.

With the feature restored in the DSL, this release also brings back the model usages that were removed when updating to DSL `10.0.0-dev.15`:
  * The `[calculation]` annotations on the `FixedAmount`, `FloatingAmount`, `YearFraction`, floating-rate processing and CSA functions
  * The `calculation`-typed attributes (`InterestRatePayout.fixedAmount`, `InterestRatePayout.floatingAmount`, `DividendReturnTerms.performance`, `PriceReturnTerms.performance`, `ReturnTermsBase.performance` and `ComputedAmount.callFunction`)

The documentation has been updated accordingly: the calculation-function section in the process model and the `InterestRatePayout` snippet in the product model once again reflect the `[calculation]` annotation and `calculation` type.

_Review Directions_

Changes can be reviewed in PR: #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)
